### PR TITLE
Fix unified diff range handling

### DIFF
--- a/src/whatthepatch/patch.py
+++ b/src/whatthepatch/patch.py
@@ -610,13 +610,13 @@ def parse_unified_diff(text):
                 if len(h.group(2)) > 0:
                     old_len = int(h.group(2))
                 else:
-                    old_len = 0
+                    old_len = 1
 
                 new = int(h.group(3))
                 if len(h.group(4)) > 0:
                     new_len = int(h.group(4))
                 else:
-                    new_len = 0
+                    new_len = 1
 
                 h = None
                 break

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -68,6 +68,13 @@ class ApplyTestSuite(unittest.TestCase):
         self.assertEqual(_apply(self.abc, diff_text), self.efg)
         self.assertEqual(_apply_r(self.efg, diff_text), self.abc)
 
+    def test_diff_unified2_bad_context(self):
+        with open("tests/casefiles/diff-unified2.diff") as f:
+            diff_text = f.read()
+
+        with pytest.raises(exceptions.ApplyException):
+            _apply(["WRONG"], diff_text)
+
     def test_diff_unified_bad(self):
         with open("tests/casefiles/diff-unified-bad.diff") as f:
             diff_text = f.read()

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -870,6 +870,7 @@ class PatchTestSuite(unittest.TestCase):
         text_diff = "\n".join(text.splitlines()[2:]) + "\n"
 
         expected = [
+            (1, 1, "The Nameless is the origin of Heaven and Earth;"),
             (None, 2, "The named is the mother of all things."),
         ]
 


### PR DESCRIPTION
## Summary
- handle omitted range lengths in unified hunk headers
- update parsing tests for unified hunks without lengths
- ensure apply_diff validates context when range lengths are omitted

## Testing
- `pytest -q`